### PR TITLE
chore: update library name and version in `package.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,27 @@
 # Changelog
 
-This project adheres to [Semantic Versioning 2.0](http://semver.org/).
-All release notes and upgrade notes can be found on our [Github Releases](https://github.com/atlassian/react-beautiful-dnd/releases) page.
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [13.1.2]
+
+### Changed
+
+- Changed package name to `@planningcenter/react-beautiful-dnd`
+- Updated author and repo information in `package.json`
+- Updated README with overview of why we forked package
+
+### Added
+
+- Added configuration files
+- Added GitHub action for building and testing code
+
+## 13.1.1 and earlier
+
+All release notes and upgrade notes for earlier versions can be found on the original
+project's [Github Releases] page.
+
+[13.1.2]: https://github.com/planningcenter/react-beautiful-dnd/compare/v13.1.1..v13.1.2
+[Github Releases]: https://github.com/atlassian/react-beautiful-dnd/releases

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-beautiful-dnd",
-  "version": "13.1.1",
+  "name": "@planningcenter/react-beautiful-dnd",
+  "version": "13.1.2",
   "description": "Beautiful and accessible drag and drop for lists with React",
   "author": "Front End Systems Engineering <frontend@planningcenter.com>",
   "keywords": [


### PR DESCRIPTION
When I was getting ready to publish to npm, I realized I had neglected to prepend `@planningcenter` to the library name when forking it. This fixes that. 

Also added relevant details to CHANGELOG in preparation for next release.