### PR TITLE
feat: skip elements w/ data-dnd-ignore-scrollable

### DIFF
--- a/src/view/use-droppable-publisher/get-closest-scrollable.js
+++ b/src/view/use-droppable-publisher/get-closest-scrollable.js
@@ -24,6 +24,10 @@ const isElementScrollable = (el: Element): boolean => {
     overflowY: style.overflowY,
   };
 
+  if (el instanceof HTMLElement && el.dataset.dndIgnoreScrollable) {
+    return false;
+  }
+
   return isEither(overflow, isScroll) || isEither(overflow, isAuto);
 };
 


### PR DESCRIPTION
Allows an element to include `data-dnd-ignore-scrollable` to not be considered a scrollable container.

This specifically addresses an issue caused in Tapestry React's DataTable component with the new Toolbar layout.