### PR TITLE
feat: use the shared publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,9 @@
+name: Use shared workflow to publish to NPM
+
+on:
+  release:
+    types: [published]
+jobs:
+  publish-to-npm:
+    uses: planningcenter/shared-workflows/.github/workflows/publish-to-npm-on-release.yml@main
+    secrets: inherit


### PR DESCRIPTION
This will publish to NPM and the GitHub package repo when we cut a GitHub release.